### PR TITLE
Use uint32_t for lengths

### DIFF
--- a/include/qmedia/neo_media_client.hh
+++ b/include/qmedia/neo_media_client.hh
@@ -42,14 +42,14 @@ extern "C"
     void  MediaClient_sendAudio(void *instance,
                                 uint64_t media_stream_id,
                                 const char *buffer,
-                                uint16_t length,
+                                uint32_t length,
                                 uint64_t timestamp);
 
     void
     MediaClient_sendVideoFrame(void *instance,
                                uint64_t streamId,
                                const char *buffer,
-                               uint16_t length,
+                               uint32_t length,
                                uint64_t timestamp,
                                bool flag);
 

--- a/src/extern/neo_media_client.cc
+++ b/src/extern/neo_media_client.cc
@@ -115,7 +115,7 @@ extern "C"
     void  MediaClient_sendAudio(void *instance,
                                     uint64_t media_stream_id,
                                     const char *buffer,
-                                    uint16_t length,
+                                    uint32_t length,
                                     uint64_t timestamp)
     {
         if (!instance)
@@ -136,7 +136,7 @@ extern "C"
  void  MediaClient_sendVideoFrame(void *instance,
                                     uint64_t media_stream_id,
                                     const char *buffer,
-                                    uint16_t length,
+                                    uint32_t length,
                                     uint64_t timestamp,
                                     bool flag)
     {


### PR DESCRIPTION
Update extern API to use 32bit unsigned for lengths. 