### PR TITLE
Changed codec type to media type.

### DIFF
--- a/ctest/neotest.cc
+++ b/ctest/neotest.cc
@@ -27,8 +27,8 @@ int main(int /*argc*/, char ** /*argv*/)
     void *pub_handle = 0;
     MediaClient_Create("127.0.0.1", 1234, &pub_handle);
 
-    std::uint64_t pub_audio_streamId = MediaClient_AddAudioStreamPublishIntent(pub_handle, 1, 0xABCD);
-    std::uint64_t pub_video_streamId = MediaClient_AddVideoStreamPublishIntent(pub_handle, 2, 0xABCD);
+    std::uint64_t pub_audio_streamId = MediaClient_AddAudioStreamPublishIntent(pub_handle, 0x01, 0xABCD);
+    std::uint64_t pub_video_streamId = MediaClient_AddVideoStreamPublishIntent(pub_handle, 0x02, 0xABCD);
 
     std::cerr << "pub audio - id " << pub_audio_streamId << std::endl;
     std::cerr << "pub video - id " << pub_video_streamId << std::endl;
@@ -50,6 +50,6 @@ int main(int /*argc*/, char ** /*argv*/)
                           vbuffer,
                           length,
                           timestamp, true);
-        //sleep(3);
+        sleep(1);
     }
 }

--- a/include/qmedia/media_client.hh
+++ b/include/qmedia/media_client.hh
@@ -72,13 +72,13 @@ public:
                          quicr::RelayInfo::Protocol protocol,
                          const LoggerPointer& s = nullptr);
 
-    MediaStreamId add_stream_subscribe(std::uint8_t codec_type, SubscribeCallback callback);
-    MediaStreamId add_audio_stream_subscribe(std::uint8_t codec_type, SubscribeCallback callback);
-    MediaStreamId add_video_stream_subscribe(std::uint8_t codec_type, SubscribeCallback callback);
+    MediaStreamId add_stream_subscribe(std::uint8_t media_type, SubscribeCallback callback);
+    MediaStreamId add_audio_stream_subscribe(std::uint8_t media_type, SubscribeCallback callback);
+    MediaStreamId add_video_stream_subscribe(std::uint8_t media_type, SubscribeCallback callback);
 
-    MediaStreamId add_publish_intent(std::uint8_t codec_type, std::uint16_t client_id);
-    MediaStreamId add_audio_publish_intent(std::uint8_t codec_type, std::uint16_t client_id);
-    MediaStreamId add_video_publish_intent(std::uint8_t codec_type, std::uint16_t client_id);
+    MediaStreamId add_publish_intent(std::uint8_t media_type, std::uint16_t client_id);
+    MediaStreamId add_audio_publish_intent(std::uint8_t media_type, std::uint16_t client_id);
+    MediaStreamId add_video_publish_intent(std::uint8_t media_type, std::uint16_t client_id);
 
     void remove_publish(MediaStreamId streamId);
     void remove_video_publish(MediaStreamId streamId);

--- a/include/qmedia/neo_media_client.hh
+++ b/include/qmedia/neo_media_client.hh
@@ -19,13 +19,13 @@ extern "C"
 
     void MediaClient_Destroy(void* media_client);
 
-    uint64_t MediaClient_AddAudioStreamPublishIntent(void* instance, uint8_t codec_type, uint16_t client_id);
+    uint64_t MediaClient_AddAudioStreamPublishIntent(void* instance, uint8_t media_type, uint16_t client_id);
 
-    uint64_t MediaClient_AddAudioStreamSubscribe(void* instance, uint8_t codec_type, SubscribeCallback callback);
+    uint64_t MediaClient_AddAudioStreamSubscribe(void* instance, uint8_t media_type, SubscribeCallback callback);
 
-    uint64_t MediaClient_AddVideoStreamPublishIntent(void* instance, uint8_t codec_type, uint16_t client_id);
+    uint64_t MediaClient_AddVideoStreamPublishIntent(void* instance, uint8_t media_type, uint16_t client_id);
 
-    uint64_t MediaClient_AddVideoStreamSubscribe(void* instance, uint8_t codec_type, SubscribeCallback callback);
+    uint64_t MediaClient_AddVideoStreamSubscribe(void* instance, uint8_t media_type, SubscribeCallback callback);
 
     void MediaClient_RemoveMediaStream(void* instance, uint64_t media_stream_id);
 

--- a/src/extern/neo_media_client.cc
+++ b/src/extern/neo_media_client.cc
@@ -27,17 +27,17 @@ extern "C"
         delete (qmedia::MediaClient*) media_client;
     }
 
-    uint64_t MediaClient_AddAudioStreamPublish(void* instance, uint8_t codec_type, uint16_t client_id)
+    uint64_t MediaClient_AddAudioStreamPublish(void* instance, uint8_t media_type, uint16_t client_id)
     {
         if (!instance)
         {
             return 0;        // invalid
         }
         auto media_client = static_cast<qmedia::MediaClient*>(instance);
-        return media_client->add_audio_publish_intent(codec_type, client_id);
+        return media_client->add_audio_publish_intent(media_type, client_id);
     }
 
-    uint64_t MediaClient_AddAudioStreamSubscribe(void* instance, uint8_t codec_type, SubscribeCallback callback)
+    uint64_t MediaClient_AddAudioStreamSubscribe(void* instance, uint8_t media_type, SubscribeCallback callback)
     {
         if (!instance)
         {
@@ -45,10 +45,10 @@ extern "C"
         }
 
         auto media_client = static_cast<qmedia::MediaClient*>(instance);
-        return media_client->add_audio_stream_subscribe(codec_type, callback);
+        return media_client->add_audio_stream_subscribe(media_type, callback);
     }
 
-    uint64_t MediaClient_AddAudioStreamPublishIntent(void* instance, uint8_t codec_type, uint16_t client_id)
+    uint64_t MediaClient_AddAudioStreamPublishIntent(void* instance, uint8_t media_type, uint16_t client_id)
     {
         if (!instance)
         {
@@ -56,10 +56,10 @@ extern "C"
         }
 
         auto media_client = static_cast<qmedia::MediaClient*>(instance);
-        return media_client->add_audio_publish_intent(codec_type, client_id);
+        return media_client->add_audio_publish_intent(media_type, client_id);
     }
 
-    uint64_t MediaClient_AddVideoStreamPublishIntent(void* instance, uint8_t codec_type, uint16_t client_id)
+    uint64_t MediaClient_AddVideoStreamPublishIntent(void* instance, uint8_t media_type, uint16_t client_id)
     {
         if (!instance)
         {
@@ -67,10 +67,10 @@ extern "C"
         }
 
         auto media_client = static_cast<qmedia::MediaClient*>(instance);
-        return media_client->add_video_publish_intent(codec_type, client_id);
+        return media_client->add_video_publish_intent(media_type, client_id);
     }
 
-    uint64_t MediaClient_AddVideoStreamSubscribe(void* instance, uint8_t codec_type, SubscribeCallback callback)
+    uint64_t MediaClient_AddVideoStreamSubscribe(void* instance, uint8_t media_type, SubscribeCallback callback)
     {
         if (!instance)
         {
@@ -78,7 +78,7 @@ extern "C"
         }
 
         auto media_client = static_cast<qmedia::MediaClient*>(instance);
-        return media_client->add_video_stream_subscribe(codec_type, callback);
+        return media_client->add_video_stream_subscribe(media_type, callback);
     }
 
     void MediaClient_RemoveMediaStream(void* instance, uint64_t /*media_stream_id*/)

--- a/src/media_client.cc
+++ b/src/media_client.cc
@@ -94,9 +94,9 @@ MediaClient::MediaClient(const char* remote_address,
     quicRClient = std::make_unique<quicr::QuicRClient>(relayInfo, logger);
 }
 
-MediaStreamId MediaClient::add_stream_subscribe(std::uint8_t codec_type, SubscribeCallback callback)
+MediaStreamId MediaClient::add_stream_subscribe(std::uint8_t media_type, SubscribeCallback callback)
 {
-    const uint8_t mediaType = codec_type << 4;        // First 4 bits is codec
+    const uint8_t mediaType = media_type;             // defined by client
     const uint16_t clientId = 0;                      // 16
     const uint64_t filler = 0;                        // 48
 
@@ -114,21 +114,21 @@ MediaStreamId MediaClient::add_stream_subscribe(std::uint8_t codec_type, Subscri
 }
 
 // TODO: Figure out if this needs specialisation
-MediaStreamId MediaClient::add_audio_stream_subscribe(std::uint8_t codec_type, SubscribeCallback callback)
+MediaStreamId MediaClient::add_audio_stream_subscribe(std::uint8_t media_type, SubscribeCallback callback)
 {
-    return add_stream_subscribe(codec_type, callback);
+    return add_stream_subscribe(media_type, callback);
 }
 
 // TODO: Figure out if this needs specialisation
-MediaStreamId MediaClient::add_video_stream_subscribe(std::uint8_t codec_type, SubscribeCallback callback)
+MediaStreamId MediaClient::add_video_stream_subscribe(std::uint8_t media_type, SubscribeCallback callback)
 {
-    return add_stream_subscribe(codec_type, callback);
+    return add_stream_subscribe(media_type, callback);
 }
 
-MediaStreamId MediaClient::add_publish_intent(std::uint8_t codec_type, std::uint16_t client_id)
+MediaStreamId MediaClient::add_publish_intent(std::uint8_t media_type, std::uint16_t client_id)
 {
     auto time = std::time(0);
-    const uint8_t mediaType = codec_type;        // 4 bits codec, 4 bits stream number
+    const uint8_t mediaType = media_type;        // defined by client
     const uint16_t clientId = client_id;         // 16
     const uint64_t uniqueId = time;              // 48 - using time for now
 
@@ -146,15 +146,15 @@ MediaStreamId MediaClient::add_publish_intent(std::uint8_t codec_type, std::uint
 }
 
 // TODO: Figure out if this needs specialisation
-MediaStreamId MediaClient::add_audio_publish_intent(std::uint8_t codec_type, std::uint16_t client_id)
+MediaStreamId MediaClient::add_audio_publish_intent(std::uint8_t media_type, std::uint16_t client_id)
 {
-    return add_publish_intent(codec_type, client_id);
+    return add_publish_intent(media_type, client_id);
 }
 
 // TODO: Figure out if this needs specialisation
-MediaStreamId MediaClient::add_video_publish_intent(std::uint8_t codec_type, std::uint16_t client_id)
+MediaStreamId MediaClient::add_video_publish_intent(std::uint8_t media_type, std::uint16_t client_id)
 {
-    return add_publish_intent(codec_type, client_id);
+    return add_publish_intent(media_type, client_id);
 }
 
 void MediaClient::remove_publish(MediaStreamId /*streamid*/)
@@ -238,6 +238,7 @@ void MediaClient::send_video_media(MediaStreamId streamid,
     quicr::bytes b(data, data + length);
     std::uint8_t* tsbytes = reinterpret_cast<std::uint8_t*>(&timestamp);        // look into network byte order
     b.insert(b.end(), tsbytes, tsbytes + sizeof(std::uint64_t));
+
     quicRClient->publishNamedObject(quicr_name, 0, 0, false, std::move(b));
     publish_names[streamid] = quicr_name;
 }


### PR DESCRIPTION
The client is handling media and codc type. So, no shifting or OR or ANDs are required.