### PR TITLE
Add profile to sub allocate

### DIFF
--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -55,7 +55,7 @@ public:
     {
     }
 
-    std::shared_ptr<qmedia::QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace)
+    std::shared_ptr<qmedia::QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace, const std::string& profile)
     {
        logger.log(qtransport::LogLevel::info, "QSubscriberTestDelegate::allocateSubByNamespace");        
        return std::make_shared<QSubscriptionTestDelegate>(quicrNamespace);

--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -55,7 +55,7 @@ public:
     {
     }
 
-    std::shared_ptr<qmedia::QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace, const std::string& profile)
+    std::shared_ptr<qmedia::QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace, const std::string& qualityProfile)
     {
        logger.log(qtransport::LogLevel::info, "QSubscriberTestDelegate::allocateSubByNamespace");        
        return std::make_shared<QSubscriptionTestDelegate>(quicrNamespace);

--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -62,7 +62,7 @@ private:
                                    bool reliableTransport,
                                    std::shared_ptr<qmedia::QPublicationDelegate>);
 
-    std::shared_ptr<QSubscriptionDelegate> getSubscriptionDelegate(const quicr::Namespace& quicrNamespace, const std::string& profile);
+    std::shared_ptr<QSubscriptionDelegate> getSubscriptionDelegate(const quicr::Namespace& quicrNamespace, const std::string& qualityProfile);
     std::shared_ptr<QPublicationDelegate> getPublicationDelegate(const quicr::Namespace& quicrNamespace);
 
     int startSubscription(std::shared_ptr<qmedia::QSubscriptionDelegate> qDelegate,

--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -62,7 +62,7 @@ private:
                                    bool reliableTransport,
                                    std::shared_ptr<qmedia::QPublicationDelegate>);
 
-    std::shared_ptr<QSubscriptionDelegate> getSubscriptionDelegate(const quicr::Namespace& quicrNamespace);
+    std::shared_ptr<QSubscriptionDelegate> getSubscriptionDelegate(const quicr::Namespace& quicrNamespace, const std::string& profile);
     std::shared_ptr<QPublicationDelegate> getPublicationDelegate(const quicr::Namespace& quicrNamespace);
 
     int startSubscription(std::shared_ptr<qmedia::QSubscriptionDelegate> qDelegate,

--- a/include/qmedia/QDelegates.hpp
+++ b/include/qmedia/QDelegates.hpp
@@ -42,7 +42,7 @@ private:
 class QSubscriberDelegate
 {
 public:
-    virtual std::shared_ptr<QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace) = 0;
+    virtual std::shared_ptr<QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace, const std::string& profile) = 0;
     virtual int removeSubByNamespace(const quicr::Namespace& quicrNamespace) = 0;
 };
 class QPublisherDelegate

--- a/include/qmedia/QDelegates.hpp
+++ b/include/qmedia/QDelegates.hpp
@@ -42,7 +42,7 @@ private:
 class QSubscriberDelegate
 {
 public:
-    virtual std::shared_ptr<QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace, const std::string& profile) = 0;
+    virtual std::shared_ptr<QSubscriptionDelegate> allocateSubByNamespace(const quicr::Namespace& quicrNamespace, const std::string& qualityProfile) = 0;
     virtual int removeSubByNamespace(const quicr::Namespace& quicrNamespace) = 0;
 };
 class QPublisherDelegate

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -221,7 +221,7 @@ QController::createQuicrPublicationDelegate(const std::string sourceId,
 /////////////
 // QController Delegates
 ////////////
-std::shared_ptr<QSubscriptionDelegate> QController::getSubscriptionDelegate(const quicr::Namespace& quicrNamespace, const std::string& profile)
+std::shared_ptr<QSubscriptionDelegate> QController::getSubscriptionDelegate(const quicr::Namespace& quicrNamespace, const std::string& qualityProfile)
 {
     if (qSubscriberDelegate)
     {
@@ -230,7 +230,7 @@ std::shared_ptr<QSubscriptionDelegate> QController::getSubscriptionDelegate(cons
         // found - return
         if (!qSubscriptionsMap.count(quicrNamespace))
         {
-            qSubscriptionsMap[quicrNamespace] = qSubscriberDelegate->allocateSubByNamespace(quicrNamespace, profile);
+            qSubscriptionsMap[quicrNamespace] = qSubscriberDelegate->allocateSubByNamespace(quicrNamespace, qualityProfile);
         }
 
         return qSubscriptionsMap[quicrNamespace];

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -221,7 +221,7 @@ QController::createQuicrPublicationDelegate(const std::string sourceId,
 /////////////
 // QController Delegates
 ////////////
-std::shared_ptr<QSubscriptionDelegate> QController::getSubscriptionDelegate(const quicr::Namespace& quicrNamespace)
+std::shared_ptr<QSubscriptionDelegate> QController::getSubscriptionDelegate(const quicr::Namespace& quicrNamespace, const std::string& profile)
 {
     if (qSubscriberDelegate)
     {
@@ -230,7 +230,7 @@ std::shared_ptr<QSubscriptionDelegate> QController::getSubscriptionDelegate(cons
         // found - return
         if (!qSubscriptionsMap.count(quicrNamespace))
         {
-            qSubscriptionsMap[quicrNamespace] = qSubscriberDelegate->allocateSubByNamespace(quicrNamespace);
+            qSubscriptionsMap[quicrNamespace] = qSubscriberDelegate->allocateSubByNamespace(quicrNamespace, profile);
         }
 
         return qSubscriptionsMap[quicrNamespace];
@@ -341,7 +341,7 @@ int QController::processSubscriptions(json& subscriptions)
             quicr::Namespace quicrNamespace = quicrNamespaceUrlParse(profile["quicrNamespaceUrl"]);
 
             // look up subscription delegate or allocate new one
-            auto qSubscriptionDelegate = getSubscriptionDelegate(quicrNamespace);
+            auto qSubscriptionDelegate = getSubscriptionDelegate(quicrNamespace, profile["qualityProfile"]);
 
             if (qSubscriptionDelegate)
             {


### PR DESCRIPTION
Adding this information allows the client to create specialized subscription implementations based on profile (codec really the variable of interest). 