### PR TITLE
Add reliable flag to prepare

### DIFF
--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -32,7 +32,7 @@ public:
         logger.log(qtransport::LogLevel::info, "QSubscriptionTestDelegate constructed");
     }
 public:
-    int prepare(const std::string& sourceId,  const std::string& label, const std::string& qualityProfile) override {
+    int prepare(const std::string& sourceId,  const std::string& label, const std::string& qualityProfile, bool& reliable) override {
         logger.log(qtransport::LogLevel::info, "QSubscriptionTestDelegate::prepare");
         return 0;
     }
@@ -94,7 +94,7 @@ public:
         logger.log(qtransport::LogLevel::info, "QPublicationTestDelegate constructed");
     }
 public:
-    int prepare(const std::string& sourceId,  const std::string& qualityProfile)  {
+    int prepare(const std::string& sourceId,  const std::string& qualityProfile, bool& reliable)  {
         logger.log(qtransport::LogLevel::info, "QPublicationTestDelegate::prepare");
         std::cerr << "pub prepare " << std::endl;
         return 0;

--- a/include/qmedia/QDelegates.hpp
+++ b/include/qmedia/QDelegates.hpp
@@ -17,7 +17,7 @@ public:
         std::cerr << "~QSubscriptionDelegate" << std::endl;
     }
 public:
-    virtual int prepare(const std::string& sourceId, const std::string& label, const std::string& qualityProfile) = 0;
+    virtual int prepare(const std::string& sourceId, const std::string& label, const std::string& qualityProfile, bool& reliable) = 0;
     virtual int update(const std::string& sourceId, const std::string& label, const std::string& qualityProfile) = 0;
     virtual int subscribedObject(quicr::bytes&& data, std::uint32_t groupId, std::uint16_t objectId) = 0;
 };
@@ -31,7 +31,7 @@ public:
     }
 
 public:
-    virtual int prepare(const std::string& sourceId, const std::string& qualityProfile) = 0;
+    virtual int prepare(const std::string& sourceId, const std::string& qualityProfile, bool& reliable) = 0;
     virtual int update(const std::string& sourceId, const std::string& qualityProfile) = 0;
     virtual void publish(bool) = 0;
 

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -376,8 +376,9 @@ int QController::processSubscriptions(json& subscriptions)
             if (rc != 0)
             {
                 // notify client to prepare for incoming media
+                bool reliable = false;
                 int prepareError = qSubscriptionDelegate->prepare(
-                    subscription["sourceId"], subscription["label"], profile["qualityProfile"]);
+                    subscription["sourceId"], subscription["label"], profile["qualityProfile"], reliable);
 
                 if (prepareError != 0)
                 {
@@ -391,7 +392,7 @@ int QController::processSubscriptions(json& subscriptions)
                                   quicrNamespace,
                                   quicr::SubscribeIntent::sync_up,
                                   "",
-                                  true,
+                                  reliable,
                                   "",
                                   e2eToken);
             }
@@ -423,7 +424,8 @@ int QController::processPublications(json& publications)
             }
 
             // Notify client to prepare for incoming media
-            int prepareError = qPublicationDelegate->prepare(publication["sourceId"], profile["qualityProfile"]);
+            bool reliable = false;
+            int prepareError = qPublicationDelegate->prepare(publication["sourceId"], profile["qualityProfile"], reliable);
             if (prepareError != 0)
             {
                 LOG_WARNING(logger, "Preparing publication \"" << quicrNamespace << "\" failed: " << prepareError);
@@ -439,7 +441,7 @@ int QController::processPublications(json& publications)
                              std::move(payload),
                              profile["priorities"],
                              profile["expiry"],
-                             true);
+                             reliable);
 
             // If singleordered, and we've successfully processed 1 delegate, break.
             if (publication["profileSet"]["type"] == SingleOrderedStr) break;


### PR DESCRIPTION
Add a referencing parameter to `prepare` so that client's can control the reliability flag. This seemed like the easiest way to add this per-track behaviour with today's client. 