### PR TITLE
Allow direct passing of transport config

### DIFF
--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -150,7 +150,12 @@ int test()
 
     //logger->Log("connecting to qController");
     then = timeSinceEpochMillisec();
-    qController->connect("127.0.0.1", 33435, quicr::RelayInfo::Protocol::QUIC);
+    qtransport::TransportConfig config {
+        .tls_cert_filename = NULL,
+        .tls_key_filename = NULL,
+        .time_queue_init_queue_size = 200,
+    };
+    qController->connect("127.0.0.1", 33435, quicr::RelayInfo::Protocol::QUIC, config);
     //qController->connect("relay.us-west-2.quicr.ctgpoc.com", 33437, quicr::RelayInfo::Protocol::QUIC);
     std::uint64_t now = timeSinceEpochMillisec();
     std::cerr << "connect duration " << now - then << std::endl;

--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -7,6 +7,7 @@
 #include <quicr/quicr_client.h>
 #include <cantina/logger.h>
 #include <UrlEncoder.h>
+#include <transport/transport.h>
 
 #include <mutex>
 #include <thread>
@@ -23,7 +24,10 @@ public:
                 std::shared_ptr<QPublisherDelegate> publisherDelegate);
 
     ~QController();
-    int connect(const std::string remoteAddress, std::uint16_t remotePort, quicr::RelayInfo::Protocol protocol);
+    int connect(const std::string remoteAddress,
+                std::uint16_t remotePort,
+                quicr::RelayInfo::Protocol protocol,
+                const qtransport::TransportConfig config);
     int disconnect();
 
     void close();

--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -27,7 +27,7 @@ public:
     int connect(const std::string remoteAddress,
                 std::uint16_t remotePort,
                 quicr::RelayInfo::Protocol protocol,
-                const qtransport::TransportConfig config);
+                const qtransport::TransportConfig& config);
     int disconnect();
 
     void close();

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -2,7 +2,6 @@
 #include <qmedia/QuicrDelegates.hpp>
 
 #include <quicr/hex_endec.h>
-#include <transport/transport.h>
 
 #include <iostream>
 #include <sstream>
@@ -42,7 +41,10 @@ QController::~QController()
     close();
 }
 
-int QController::connect(const std::string remoteAddress, std::uint16_t remotePort, quicr::RelayInfo::Protocol protocol)
+int QController::connect(const std::string remoteAddress,
+                         std::uint16_t remotePort,
+                         quicr::RelayInfo::Protocol protocol,
+                         const qtransport::TransportConfig config)
 {
     quicr::RelayInfo relayInfo = {
         .hostname = remoteAddress.c_str(),
@@ -50,13 +52,7 @@ int QController::connect(const std::string remoteAddress, std::uint16_t remotePo
         .proto = protocol,
     };
 
-    qtransport::TransportConfig tcfg{
-        .tls_cert_filename = NULL,
-        .tls_key_filename = NULL,
-        .time_queue_init_queue_size = 200,
-    };
-
-    quicrClient = std::make_unique<quicr::QuicRClient>(relayInfo, std::move(tcfg), logger);
+    quicrClient = std::make_unique<quicr::QuicRClient>(relayInfo, config, logger);
 
     if (!quicrClient->connect()) return -1;
 

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -44,7 +44,7 @@ QController::~QController()
 int QController::connect(const std::string remoteAddress,
                          std::uint16_t remotePort,
                          quicr::RelayInfo::Protocol protocol,
-                         const qtransport::TransportConfig config)
+                         const qtransport::TransportConfig& config)
 {
     quicr::RelayInfo relayInfo = {
         .hostname = remoteAddress.c_str(),


### PR DESCRIPTION
Allows callers to provide the desired transport configuration on connection.

The `RelayInfo` might make sense to subsequently be passed like this also. 