### PR TITLE
Papercuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@
 BUILD_DIR=build
 CLANG_FORMAT=clang-format -i
 
-.PHONY: all clean cclean format
+.PHONY: all build clean cclean format
 
 all: build
 	cmake --build build
 
-build: CMakeLists.txt test/CMakeLists.txt cmd/CMakeLists.txt
+build: CMakeLists.txt
 	cmake -Bbuild -DCMAKE_BUILD_TYPE=Debug -DQMEDIA_BUILD_TESTS=ON -DBUILD_TESTING=ON  .
 
 clean:
@@ -24,5 +24,5 @@ cclean:
 format:
 	find include -iname "*.hh" -or -iname "*.cc" | xargs ${CLANG_FORMAT}
 	find src -iname "*.hh" -or -iname "*.cc" | xargs ${CLANG_FORMAT}
-	find cmd -iname "*.hh" -or -iname "*.cc" | xargs ${CLANG_FORMAT}
+	find qtest -iname "*.hh" -or -iname "*.cc" | xargs ${CLANG_FORMAT}
 	find test -iname "*.hh" -or -iname "*.cc" | xargs ${CLANG_FORMAT}

--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -89,7 +89,7 @@ class QPublicationTestDelegate : public qmedia::QPublicationDelegate
 {
 public:
     QPublicationTestDelegate(const quicr::Namespace& quicrNamespace) :
-        qmedia::QPublicationDelegate(quicrNamespace),
+        qmedia::QPublicationDelegate(),
         logger(std::make_shared<cantina::Logger>("Qmedia", "TEST"))
     //quicrNamespace(quicrNamespace)
     {

--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -37,9 +37,9 @@ public:
     [[deprecated("Use QController::disconnect instead")]] void close();
 
     [[deprecated("Use parsed Manifest object instead of string")]]
-    int updateManifest(const std::string& manifest_json);
+    void updateManifest(const std::string& manifest_json);
 
-    int updateManifest(const manifest::Manifest& manifest_obj);
+    void updateManifest(const manifest::Manifest& manifest_obj);
 
     void publishNamedObject(const quicr::Namespace& quicrNamespace, std::uint8_t* data, std::size_t len, bool groupFlag);
     void publishNamedObjectTest(std::uint8_t* data, std::size_t len, bool groupFlag);
@@ -114,9 +114,9 @@ private:
 
     void stopPublication(const quicr::Namespace& quicrNamespace);
 
-    int processURLTemplates(const std::vector<std::string>& urlTemplates);
-    int processSubscriptions(const std::vector<manifest::Subscription>& subscriptions);
-    int processPublications(const std::vector<manifest::Publication>& publications);
+    void processURLTemplates(const std::vector<std::string>& urlTemplates);
+    void processSubscriptions(const std::vector<manifest::Subscription>& subscriptions);
+    void processPublications(const std::vector<manifest::Publication>& publications);
 
 private:
     std::mutex qSubsMutex;

--- a/include/qmedia/QDelegates.hpp
+++ b/include/qmedia/QDelegates.hpp
@@ -26,16 +26,9 @@ public:
 class QPublicationDelegate
 {
 public:
-    QPublicationDelegate(const quicr::Namespace& quicrNamespace) : quicrNamespace(quicrNamespace), publishFlag(true) {}
-
-public:
     virtual int prepare(const std::string& sourceId, const std::string& qualityProfile, bool& reliable) = 0;
     virtual int update(const std::string& sourceId, const std::string& qualityProfile) = 0;
     virtual void publish(bool) = 0;
-
-private:
-    quicr::Namespace quicrNamespace;
-    bool publishFlag;
 };
 
 class QSubscriberDelegate

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -364,7 +364,7 @@ int QController::startPublication(std::shared_ptr<qmedia::QPublicationDelegate> 
     return 0;
 }
 
-int QController::processURLTemplates(const std::vector<std::string>& urlTemplates)
+void QController::processURLTemplates(const std::vector<std::string>& urlTemplates)
 {
     LOGGER_DEBUG(logger, "Processing URL templates...");
     for (auto& urlTemplate : urlTemplates)
@@ -372,10 +372,9 @@ int QController::processURLTemplates(const std::vector<std::string>& urlTemplate
         encoder.AddTemplate(urlTemplate, true);
     }
     LOGGER_INFO(logger, "Finished processing templates!");
-    return 0;
 }
 
-int QController::processSubscriptions(const std::vector<manifest::Subscription>& subscriptions)
+void QController::processSubscriptions(const std::vector<manifest::Subscription>& subscriptions)
 {
     LOGGER_DEBUG(logger, "Processing subscriptions...");
     for (auto& subscription : subscriptions)
@@ -423,10 +422,9 @@ int QController::processSubscriptions(const std::vector<manifest::Subscription>&
     }
 
     LOGGER_INFO(logger, "Finished processing subscriptions!");
-    return 0;
 }
 
-int QController::processPublications(const std::vector<manifest::Publication>& publications)
+void QController::processPublications(const std::vector<manifest::Publication>& publications)
 {
     LOGGER_DEBUG(logger, "Processing publications...");
     for (auto& publication : publications)
@@ -468,20 +466,19 @@ int QController::processPublications(const std::vector<manifest::Publication>& p
     }
 
     LOGGER_INFO(logger, "Finished processing publications!");
-    return 0;
 }
 
-int QController::updateManifest(const std::string& manifest_json)
+void QController::updateManifest(const std::string& manifest_json)
 {
   LOGGER_DEBUG(logger, "Parsing manifest...");
   const auto manifest_parsed = json::parse(manifest_json);
   const auto manifest_obj = manifest::Manifest(manifest_parsed);
   LOGGER_INFO(logger, "Finished parsing manifest!");
 
-  return updateManifest(manifest_obj);
+  updateManifest(manifest_obj);
 }
 
-int QController::updateManifest(const manifest::Manifest& manifest_obj)
+void QController::updateManifest(const manifest::Manifest& manifest_obj)
 {
     LOGGER_DEBUG(logger, "Importing manifest...");
 
@@ -490,8 +487,6 @@ int QController::updateManifest(const manifest::Manifest& manifest_obj)
     processPublications(manifest_obj.publications);
 
     LOGGER_INFO(logger, "Finished importing manifest!");
-
-    return 0;
 }
 
 }        // namespace qmedia

--- a/src/QSFrameContext.cpp
+++ b/src/QSFrameContext.cpp
@@ -67,7 +67,6 @@ void QSFrameContext::ensure_key(uint64_t epoch_id,
         ns_contexts.emplace(quicr_namespace, sframe::ContextBase(cipher_suite));
     }
 
-    const auto &epoch_secret = epoch_secrets.at(epoch_id);
     const auto base_key = derive_base_key(epoch_id, quicr_namespace);
     ns_contexts.at(quicr_namespace).add_key(epoch_id, base_key);
 }


### PR DESCRIPTION
* When a function returning `int` always returns `0` and nothing ever checks the return value, it's clearer to return `void`
* Cleaned up some unused fields variables that the compiler was warning about
* Fixed the Makefile so that `make` actually works