### PR TITLE
Have publish/subscribe block on response

### DIFF
--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -96,16 +96,18 @@ public:
         logger->Log("QPublicationTestDelegate constructed");
     }
 public:
-    int prepare(const std::string& sourceId,  const std::string& qualityProfile, bool& reliable)  {
+    int prepare(const std::string& sourceId,  const std::string& qualityProfile, bool& reliable) override  {
         logger->Log("QPublicationTestDelegate::prepare");
         std::cerr << "pub prepare " << std::endl;
         return 0;
     }
-    int update(const std::string& sourceId, const std::string& qualityProfile) {
+
+    int update(const std::string& sourceId, const std::string& qualityProfile) override {
         logger->Log("QPublicationTestDelegate::update");
         return 1; //1 = needs prepare
     }
-    void publish(bool pubFlag) {
+
+    void publish(bool pubFlag) override {
         logger->Log("QPublicationTestDelegate::publish");
     }
 

--- a/test/qmedia.cpp
+++ b/test/qmedia.cpp
@@ -15,7 +15,6 @@ using namespace std::chrono_literals;
 
 struct SubscriptionCollector
 {
-
     SubscriptionCollector() : object_future(object_promise.get_future()) {}
 
     void add_object(quicr::bytes&& data)
@@ -53,15 +52,17 @@ struct SubscriptionCollector
     }
 
     // Thread-safe, unwrapping accessors
-#define STRING_ACCESSOR(field_name) \
-    void field_name(std::string field_name) { \
-      const auto _ = std::lock_guard(object_mutex); \
-      _##field_name = std::move(field_name); \
-    } \
-    \
-    std::string field_name() { \
-      const auto _ = std::lock_guard(object_mutex); \
-      return _##field_name.value(); \
+#define STRING_ACCESSOR(field_name)                   \
+    void field_name(std::string field_name)           \
+    {                                                 \
+        const auto _ = std::lock_guard(object_mutex); \
+        _##field_name = std::move(field_name);        \
+    }                                                 \
+                                                      \
+    std::string field_name()                          \
+    {                                                 \
+        const auto _ = std::lock_guard(object_mutex); \
+        return _##field_name.value();                 \
     }
 
     STRING_ACCESSOR(sourceId)
@@ -149,14 +150,16 @@ class QPublicationTestDelegate : public qmedia::QPublicationDelegate
 public:
     virtual ~QPublicationTestDelegate() = default;
 
-    int prepare(const std::string& /* sourceId */, const std::string& /* qualityProfile */, bool& /* reliable */)
+    int prepare(const std::string& /* sourceId */,
+                const std::string& /* qualityProfile */,
+                bool& /* reliable */) override
     {
         return 0;
     }
 
-    int update(const std::string& /* sourceId */, const std::string& /* qualityProfile */) { return 0; }
+    int update(const std::string& /* sourceId */, const std::string& /* qualityProfile */) override { return 0; }
 
-    void publish(bool /* pubFlag */) {}
+    void publish(bool /* pubFlag */) override {}
 };
 
 class QPublisherTestDelegate : public qmedia::QPublisherDelegate


### PR DESCRIPTION
@TimEvens noted that the tests introduced in #71 are racy, in that they will fail if one party hasn't subscribed before the other starts transmitting.  This is a consequence of the general fact that Qmedia ignores responses from the relay, and thus blithely waits for subscriptions that will never deliver, and publishes on namespaces it is not authorized for.

This PR makes it so that the `subscribe` and `publishIntent` methods on the Quicr delegates block until the corresponding response is received from the relay (or a timer expires, resulting in failure).  This will make manifest processing and periodic resubscribes slower, taking `(N_pub + N_sub) * RTT`, since it will await each response in sequence.  These serial requests could be made parallel by returning the futures to QController and waiting on them as a batch.