### PR TITLE
Expose transport mode

### DIFF
--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -34,6 +34,7 @@ public:
     }
 public:
     int prepare(const std::string& sourceId, const std::string& label, const qmedia::manifest::ProfileSet& profileSet, quicr::TransportMode& transportMode) override {
+        transportMode = quicr::TransportMode::ReliablePerGroup;
         logger->Log("QSubscriptionTestDelegate::prepare");
         return 0;
     }
@@ -96,7 +97,8 @@ public:
         logger->Log("QPublicationTestDelegate constructed");
     }
 public:
-    int prepare(const std::string& sourceId,  const std::string& qualityProfile, quicr::TransportMode& reliable)  {
+    int prepare(const std::string& sourceId,  const std::string& qualityProfile, quicr::TransportMode& transportMode)  {
+        transportMode = quicr::TransportMode::ReliablePerGroup;
         logger->Log("QPublicationTestDelegate::prepare");
         std::cerr << "pub prepare " << std::endl;
         return 0;

--- a/ctest/qtest.cpp
+++ b/ctest/qtest.cpp
@@ -33,7 +33,7 @@ public:
         logger->Log("QSubscriptionTestDelegate constructed");
     }
 public:
-    int prepare(const std::string& sourceId, const std::string& label, const qmedia::manifest::ProfileSet& profileSet, bool& reliable) override {
+    int prepare(const std::string& sourceId, const std::string& label, const qmedia::manifest::ProfileSet& profileSet, quicr::TransportMode& transportMode) override {
         logger->Log("QSubscriptionTestDelegate::prepare");
         return 0;
     }
@@ -96,7 +96,7 @@ public:
         logger->Log("QPublicationTestDelegate constructed");
     }
 public:
-    int prepare(const std::string& sourceId,  const std::string& qualityProfile, bool& reliable)  {
+    int prepare(const std::string& sourceId,  const std::string& qualityProfile, quicr::TransportMode& reliable)  {
         logger->Log("QPublicationTestDelegate::prepare");
         std::cerr << "pub prepare " << std::endl;
         return 0;

--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -95,7 +95,7 @@ private:
                                     const quicr::Namespace& quicrNamespace,
                                     const quicr::SubscribeIntent intent,
                                     const std::string& originUrl,
-                                    const bool useReliableTransport,
+                                    const quicr::TransportMode transportMode,
                                     const std::string& authToken,
                                     quicr::bytes&& e2eToken,
                                     std::shared_ptr<qmedia::QSubscriptionDelegate> delegate);
@@ -110,7 +110,7 @@ private:
                                                                         quicr::bytes&& payload,
                                                                         const std::vector<std::uint8_t>& priority,
                                                                         const std::vector<std::uint16_t>& expiry,
-                                                                        bool reliableTransport);
+                                                                        const quicr::TransportMode transportMode);
 
     std::shared_ptr<QSubscriptionDelegate> getSubscriptionDelegate(const SourceId& sourceId,
                                                                    const manifest::ProfileSet& profileSet);
@@ -124,7 +124,7 @@ private:
                           const quicr::Namespace& quicrNamespace,
                           const quicr::SubscribeIntent intent,
                           const std::string& originUrl,
-                          const bool useReliableTransport,
+                          const quicr::TransportMode transportMode,
                           const std::string& authToken,
                           quicr::bytes& e2eToken);
 
@@ -136,7 +136,7 @@ private:
                          quicr::bytes&& payload,
                          const std::vector<std::uint8_t>& priority,
                          const std::vector<std::uint16_t>& expiry,
-                         bool reliableTransport);
+                         const quicr::TransportMode transportMode);
 
     void stopPublication(const quicr::Namespace& quicrNamespace);
 
@@ -151,7 +151,6 @@ private:
     std::mutex pubsMutex;
 
     const cantina::LoggerPointer logger;
-    const quicr::TransportMode _def_reliable_mode = quicr::TransportMode::ReliablePerGroup;
 
     std::shared_ptr<QSubscriberDelegate> qSubscriberDelegate;
     std::shared_ptr<QPublisherDelegate> qPublisherDelegate;

--- a/include/qmedia/QDelegates.hpp
+++ b/include/qmedia/QDelegates.hpp
@@ -19,7 +19,7 @@ public:
     virtual int prepare(const std::string& sourceId,
                         const std::string& label,
                         const manifest::ProfileSet& profiles,
-                        bool& reliable) = 0;
+                        quicr::TransportMode& transportMode) = 0;
     virtual int update(const std::string& sourceId, const std::string& label, const manifest::ProfileSet& profiles) = 0;
     virtual int subscribedObject(const quicr::Namespace& quicrNamespace, quicr::bytes&& data, std::uint32_t groupId, std::uint16_t objectId) = 0;
 };
@@ -27,7 +27,7 @@ public:
 class QPublicationDelegate
 {
 public:
-    virtual int prepare(const std::string& sourceId, const std::string& qualityProfile, bool& reliable) = 0;
+    virtual int prepare(const std::string& sourceId, const std::string& qualityProfile, quicr::TransportMode& reliable) = 0;
     virtual int update(const std::string& sourceId, const std::string& qualityProfile) = 0;
     virtual void publish(bool) = 0;
 };

--- a/include/qmedia/QDelegates.hpp
+++ b/include/qmedia/QDelegates.hpp
@@ -27,7 +27,7 @@ public:
 class QPublicationDelegate
 {
 public:
-    virtual int prepare(const std::string& sourceId, const std::string& qualityProfile, quicr::TransportMode& reliable) = 0;
+    virtual int prepare(const std::string& sourceId, const std::string& qualityProfile, quicr::TransportMode& transportMode) = 0;
     virtual int update(const std::string& sourceId, const std::string& qualityProfile) = 0;
     virtual void publish(bool) = 0;
 };

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -383,8 +383,8 @@ void QController::processSubscriptions(const std::vector<manifest::MediaStream>&
             continue;
         }
         
-        auto reliable = quicr::TransportMode::Unreliable;
-        int prepare_error = delegate->prepare(subscription.sourceId, subscription.label, subscription.profileSet, reliable);
+        auto transportMode = quicr::TransportMode::Unreliable;
+        int prepare_error = delegate->prepare(subscription.sourceId, subscription.label, subscription.profileSet, transportMode);
         if (prepare_error != 0)
         {
             LOGGER_ERROR(logger, "Error preparing subscription: " << prepare_error);
@@ -399,7 +399,7 @@ void QController::processSubscriptions(const std::vector<manifest::MediaStream>&
                               profile.quicrNamespace,
                               quicr::SubscribeIntent::sync_up,
                               "",
-                              reliable,
+                              transportMode,
                               "",
                               e2eToken);
 
@@ -427,8 +427,8 @@ void QController::processPublications(const std::vector<manifest::MediaStream>& 
             }
 
             // Notify client to prepare for incoming media
-            quicr::TransportMode reliable = quicr::TransportMode::Unreliable;
-            int prepare_error = delegate->prepare(publication.sourceId, profile.qualityProfile, reliable);
+            auto transportMode = quicr::TransportMode::Unreliable;
+            int prepare_error = delegate->prepare(publication.sourceId, profile.qualityProfile, transportMode);
             if (prepare_error != 0)
             {
                 LOGGER_WARNING(logger,
@@ -445,7 +445,7 @@ void QController::processPublications(const std::vector<manifest::MediaStream>& 
                              std::move(payload),
                              profile.priorities,
                              profile.expiry,
-                             reliable);
+                             transportMode);
 
             // If singleordered, and we've successfully processed 1 delegate, break.
             if (is_singleordered_publication) break;

--- a/test/qmedia.cpp
+++ b/test/qmedia.cpp
@@ -107,8 +107,9 @@ public:
     int prepare(const std::string& sourceId,
                 const std::string& label,
                 const qmedia::manifest::ProfileSet& /* profileSet */,
-                bool& /* reliable */) override
+                quicr::TransportMode& transportMode) override
     {
+        transportMode = quicr::TransportMode::ReliablePerGroup;
         collector->sourceId(sourceId);
         collector->label(label);
         // collector->qualityProfile(profileSet);
@@ -157,8 +158,9 @@ class QPublicationTestDelegate : public qmedia::QPublicationDelegate
 public:
     virtual ~QPublicationTestDelegate() = default;
 
-    int prepare(const std::string& /* sourceId */, const std::string& /* qualityProfile */, bool& /* reliable */)
+    int prepare(const std::string& /* sourceId */, const std::string& /* qualityProfile */, quicr::TransportMode& transportMode)
     {
+        transportMode = quicr::TransportMode::ReliablePerGroup;
         return 0;
     }
 

--- a/test/qmedia.cpp
+++ b/test/qmedia.cpp
@@ -105,7 +105,7 @@ public:
     int prepare(const std::string& sourceId,
                 const std::string& label,
                 const qmedia::manifest::ProfileSet& /* profileSet */,
-                bool& /* reliable */) override
+                quicr::TransportMode& /* reliable */) override
     {
         collector->sourceId(sourceId);
         collector->label(label);
@@ -155,7 +155,7 @@ class QPublicationTestDelegate : public qmedia::QPublicationDelegate
 public:
     virtual ~QPublicationTestDelegate() = default;
 
-    int prepare(const std::string& /* sourceId */, const std::string& /* qualityProfile */, bool& /* reliable */)
+    int prepare(const std::string& /* sourceId */, const std::string& /* qualityProfile */, quicr::TransportMode& /* reliable */)
     {
         return 0;
     }

--- a/test/qmedia.cpp
+++ b/test/qmedia.cpp
@@ -109,9 +109,9 @@ public:
                 const qmedia::manifest::ProfileSet& /* profileSet */,
                 quicr::TransportMode& transportMode) override
     {
-        transportMode = quicr::TransportMode::ReliablePerGroup;
         collector->sourceId(sourceId);
         collector->label(label);
+        transportMode = quicr::TransportMode::ReliablePerGroup; // Testing microbursts data, which often results in drops. Use reliable for tests.
         // collector->qualityProfile(profileSet);
         return 0;
     }
@@ -160,7 +160,7 @@ public:
 
     int prepare(const std::string& /* sourceId */, const std::string& /* qualityProfile */, quicr::TransportMode& transportMode)
     {
-        transportMode = quicr::TransportMode::ReliablePerGroup;
+        transportMode = quicr::TransportMode::ReliablePerGroup; // Testing microbursts data, which often results in drops. Use reliable for tests.
         return 0;
     }
 


### PR DESCRIPTION
Expose `TransportMode` in client facing APIs, rather than opaque reliable bool. 