### PR TITLE
Allow passing of optional logger

### DIFF
--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -29,7 +29,8 @@ public:
 
     QController(std::shared_ptr<QSubscriberDelegate> subscriberDelegate,
                 std::shared_ptr<QPublisherDelegate> publisherDelegate,
-                const cantina::LoggerPointer& logger);
+                const cantina::LoggerPointer& logger,
+                const bool debugging = false);
 
     ~QController();
 

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -14,7 +14,7 @@ QController::QController(std::shared_ptr<QSubscriberDelegate> qSubscriberDelegat
                          std::shared_ptr<QPublisherDelegate> qPublisherDelegate,
                          const cantina::LoggerPointer& logger,
                          const bool debugging) :
-    logger(std::make_shared<cantina::Logger>("QCTRL")),
+    logger(std::make_shared<cantina::Logger>("QCTRL", logger)),
     qSubscriberDelegate(std::move(qSubscriberDelegate)),
     qPublisherDelegate(std::move(qPublisherDelegate)),
     stop(false),

--- a/src/QController.cpp
+++ b/src/QController.cpp
@@ -12,19 +12,20 @@ namespace qmedia
 
 QController::QController(std::shared_ptr<QSubscriberDelegate> qSubscriberDelegate,
                          std::shared_ptr<QPublisherDelegate> qPublisherDelegate,
-                         const cantina::LoggerPointer& logger) :
+                         const cantina::LoggerPointer& logger,
+                         const bool debugging) :
     logger(std::make_shared<cantina::Logger>("QCTRL")),
     qSubscriberDelegate(std::move(qSubscriberDelegate)),
     qPublisherDelegate(std::move(qPublisherDelegate)),
     stop(false),
     closed(false)
 {
-
-    if (logger->IsDebugging())
+    // If there's a parent logger, its log level will be used.
+    // Otherwise, query the debugging flag.
+    if (logger == nullptr && debugging)
     {
-        this->logger->SetLogLevel("DEBUG");
+        this->logger->SetLogLevel(cantina::LogLevel::Debug);
     }
-    
     LOGGER_DEBUG(logger, "QController started...");
 
     // quicr://webex.cisco.com/conference/1/mediaType/192/endpoint/2

--- a/test/qmedia.cpp
+++ b/test/qmedia.cpp
@@ -481,3 +481,14 @@ TEST_CASE("Subscription set/get state")
     const quicr::SubscriptionState& pausedState = controller.getSubscriptionState(media.profileSet.profiles[0].quicrNamespace);
     REQUIRE(pausedState == quicr::SubscriptionState::Paused);
 }
+
+TEST_CASE("Parent logger")
+{
+    bool messageReceived = false;
+    auto parent = std::make_shared<cantina::CustomLogger>([&messageReceived](auto level, const std::string& msg, bool) {
+        messageReceived |= (msg == "QController started..." && level == cantina::LogLevel::Debug);
+    });
+    parent->SetLogLevel(cantina::LogLevel::Debug);
+    auto controller = qmedia::QController(nullptr, nullptr, parent);
+    REQUIRE(messageReceived);
+}


### PR DESCRIPTION
Re-add the optional ability to pass in a parent logger. If none is provided, a new one will be created for internal use. The debugging flag has been added to set the log level to debug of that internal logger - if a parent logger is provided then the log level is inherited and that flag has no effect. 