### PR TITLE
Update libquicr to fix invalid drops, support peering metrics and bring in srtt adjustments

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: recursive
 
     - name: Install Packages
-      run: brew install pkgconfig
+      run: brew install pkgconfig go
       if: matrix.os != 'ubuntu-latest'
 
     - name: Configure CMake


### PR DESCRIPTION
Updates libquicr which brings in peering metrics support, fixes critical bug causing invalid drops, and updates picoquic to `adjust-srtt` branch. 