### PR TITLE
Add support for disabling sframe

### DIFF
--- a/include/qmedia/QController.hpp
+++ b/include/qmedia/QController.hpp
@@ -11,12 +11,16 @@
 
 #include <mutex>
 #include <thread>
+#include <optional>
+#include <sframe/sframe.h>
 
 using json = nlohmann::json;
 using SourceId = std::string;
 
 namespace qmedia
 {
+
+constexpr sframe::CipherSuite Default_Cipher_Suite = sframe::CipherSuite::AES_GCM_128_SHA256;
 
 class QController
 {
@@ -30,7 +34,8 @@ public:
     QController(std::shared_ptr<QSubscriberDelegate> subscriberDelegate,
                 std::shared_ptr<QPublisherDelegate> publisherDelegate,
                 const cantina::LoggerPointer& logger,
-                const bool debugging = false);
+                const bool debugging = false,
+                const std::optional<sframe::CipherSuite> cipherSuite = Default_Cipher_Suite);
 
     ~QController();
 
@@ -97,7 +102,8 @@ private:
                                     const quicr::TransportMode transportMode,
                                     const std::string& authToken,
                                     quicr::bytes&& e2eToken,
-                                    std::shared_ptr<qmedia::QSubscriptionDelegate> delegate);
+                                    std::shared_ptr<qmedia::QSubscriptionDelegate> delegate,
+                                    const std::optional<sframe::CipherSuite> cipherSuite);
 
     std::shared_ptr<PublicationDelegate> findQuicrPublicationDelegate(const quicr::Namespace& quicrNamespace);
 
@@ -166,6 +172,7 @@ private:
     bool closed;
     bool is_singleordered_subscription = true;
     bool is_singleordered_publication = false;
+    std::optional<sframe::CipherSuite> cipher_suite;
 };
 
 }        // namespace qmedia

--- a/include/qmedia/QSFrameContext.hpp
+++ b/include/qmedia/QSFrameContext.hpp
@@ -15,6 +15,7 @@ class QSFrameContext
 {
 public:
     QSFrameContext(sframe::CipherSuite cipher_suite);
+    QSFrameContext(QSFrameContext& other);
 
     void addEpoch(uint64_t epoch_id, const quicr::bytes& epoch_secret);
     void enableEpoch(uint64_t epoch_id);

--- a/include/qmedia/QuicrDelegates.hpp
+++ b/include/qmedia/QuicrDelegates.hpp
@@ -9,6 +9,7 @@
 #include <quicr/quicr_common.h>
 #include <quicr/quicr_client.h>
 
+#include <optional>
 #include <string>
 
 namespace qmedia
@@ -24,7 +25,8 @@ class SubscriptionDelegate : public quicr::SubscriberDelegate, public std::enabl
                          const std::string& authToken,
                          quicr::bytes e2eToken,
                          std::shared_ptr<qmedia::QSubscriptionDelegate> qDelegate,
-                         const cantina::LoggerPointer& logger);
+                         const cantina::LoggerPointer& logger,
+                         const std::optional<sframe::CipherSuite> cipherSuite);
 
 public:
     [[nodiscard]] static std::shared_ptr<SubscriptionDelegate>
@@ -36,7 +38,8 @@ public:
            const std::string& authToken,
            quicr::bytes e2eToken,
            std::shared_ptr<qmedia::QSubscriptionDelegate> qDelegate,
-           const cantina::LoggerPointer& logger);
+           const cantina::LoggerPointer& logger,
+           const std::optional<sframe::CipherSuite> cipherSuite);
 
     std::shared_ptr<SubscriptionDelegate> getptr() { return shared_from_this(); }
 
@@ -86,7 +89,7 @@ private:
     std::uint32_t currentGroupId;
     std::uint16_t currentObjectId;
 
-    QSFrameContext sframe_context;
+    std::optional<QSFrameContext> sframe_context;
 };
 
 class PublicationDelegate : public quicr::PublisherDelegate, public std::enable_shared_from_this<PublicationDelegate>
@@ -100,7 +103,8 @@ class PublicationDelegate : public quicr::PublisherDelegate, public std::enable_
                         quicr::bytes&& payload,
                         const std::vector<std::uint8_t>& priority,
                         const std::vector<std::uint16_t>& expiry,
-                        const cantina::LoggerPointer& logger);
+                        const cantina::LoggerPointer& logger,
+                        const std::optional<sframe::CipherSuite> cipherSuite);
 
 public:
     [[nodiscard]] static std::shared_ptr<PublicationDelegate>
@@ -113,7 +117,8 @@ public:
            quicr::bytes&& payload,
            const std::vector<std::uint8_t>& priority,
            const std::vector<std::uint16_t>& expiry,
-           const cantina::LoggerPointer& logger);
+           const cantina::LoggerPointer& logger,
+           const std::optional<sframe::CipherSuite> cipherSuite);
 
     std::shared_ptr<PublicationDelegate> getptr() { return shared_from_this(); }
 
@@ -156,6 +161,6 @@ private:
     std::shared_ptr<qmedia::QPublicationDelegate> qDelegate;
     const cantina::LoggerPointer logger;
 
-    QSFrameContext sframe_context;
+    std::optional<QSFrameContext> sframe_context;
 };
 }        // namespace qmedia

--- a/src/QSFrameContext.cpp
+++ b/src/QSFrameContext.cpp
@@ -9,6 +9,15 @@ QSFrameContext::QSFrameContext(sframe::CipherSuite cipher_suite) : cipher_suite(
     // Nothing more to do
 }
 
+QSFrameContext::QSFrameContext(QSFrameContext& other)
+{
+    std::lock_guard<std::mutex> lock(other.context_mutex);
+    cipher_suite = other.cipher_suite;
+    current_epoch = other.current_epoch;
+    epoch_secrets = other.epoch_secrets;
+    ns_contexts = other.ns_contexts;
+}
+
 void QSFrameContext::addEpoch(uint64_t epoch_id, const quicr::bytes& epoch_secret)
 {
     std::lock_guard<std::mutex> lock(context_mutex);


### PR DESCRIPTION
Exposes target sframe cipher as a parameter on publication and subscription delegate creation. Optionally, null can be provided in order to skip encryption/decryption altogether. 